### PR TITLE
installer: add Codex CLI fallback for patch failures

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ Or use the helper script:
 
 **App opens a blank window**
 - Make sure the patch applied (installer output should say “patched main.js”).
+- If patching fails with a pattern error, use the Codex CLI fallback shown by `install.sh` to update patch logic in `install.sh`, then rerun the installer.
 
 **Native module load error**
 - Delete `codex-app/` and rerun `install.sh`.


### PR DESCRIPTION
## Problem
The patch logic for `Codex.dmg` can drift when upstream bundle patterns change, which leads to repeated one-off repatches.

## What This PR Changes
- Wraps the main-entry patch step in `install.sh` with explicit failure handling and error logging.
- On patch failure, prints a Codex CLI fallback command that helps users update `install.sh` patch logic for their specific DMG build.
- Updates `README.md` troubleshooting to direct users to that Codex CLI fallback flow.

## Why This Approach
Instead of repeatedly hardcoding new patch variants, we provide a guided recovery path using Codex CLI so users can adapt safely to new DMG patterns and rerun the installer.

## Validation
- `bash -n install.sh`
