### PR TITLE
fix(installer): stream native rebuild logs and clarify warning semantics

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,12 @@ chmod +x install.sh
 ./install.sh /path/to/Codex.dmg
 ```
 
+Verbose native rebuild output:
+
+```bash
+./install.sh -v /path/to/Codex.dmg
+```
+
 ### Option B: Auto‑download DMG
 
 If you have the DMG URL, you can pass it directly:
@@ -86,6 +92,9 @@ Or use the helper script:
 - Auto‑update is disabled (Sparkle is macOS‑only and removed).
 - The app may show warnings about `url.parse` deprecation — safe to ignore.
 - The app expects the Codex CLI on your PATH. If you installed it globally, that’s already done.
+- During native rebuild, upstream modules can emit compiler warnings; this is expected as long as rebuild finishes with `Rebuild OK`.
+- Native rebuild output is saved under `work/logs/` by default (for example `work/logs/rebuild-better-sqlite3.log`).
+- To stream full native rebuild output live, run with `./install.sh -v ...` (or set `NATIVE_REBUILD_VERBOSE=1`).
 
 ## Troubleshooting
 
@@ -95,6 +104,11 @@ Or use the helper script:
 
 **Native module load error**
 - Delete `codex-app/` and rerun `install.sh`.
+
+**Compiler warnings during install**
+- Warnings from `better-sqlite3` and `node-pty` can be normal with newer toolchains.
+- Treat the run as successful if installer output shows `Rebuild OK: better-sqlite3` and `Rebuild OK: node-pty`.
+- If rebuild fails, inspect `work/logs/rebuild-*.log`.
 
 **Gatekeeper warning**
 - Right‑click the app → Open (once) to allow it.


### PR DESCRIPTION
## Summary
This PR improves native module rebuild UX in `install.sh` by making output concise by default while keeping full diagnostics available on demand.

## Why
Installer runs frequently emit upstream compiler warnings from `better-sqlite3` and `node-pty`. Showing full compiler output every run can make successful installs look noisy or suspicious, while still needing full logs for debugging failed rebuilds.

## Changes
- add installer CLI flags:
  - `-v` / `--verbose` to stream native rebuild output live
  - `-h` / `--help` for explicit usage output
- keep native rebuild output quiet by default and persist full logs to:
  - `work/logs/rebuild-better-sqlite3.log`
  - `work/logs/rebuild-node-pty.log`
- keep explicit per-module progress and warning-semantics messaging:
  - `Rebuilding <module>...`
  - `Rebuild OK: <module> (...)`
- preserve opt-in environment control (`NATIVE_REBUILD_VERBOSE=1`) alongside the new `-v` flag
- on rebuild failure, print log path and a rerun hint with verbose mode
- update README install + notes to document default behavior and `-v` usage


## Logs difference

Before
<details>

```
➜  codex-intel git:(main) ✗ ./install.sh ~/Downloads/Codex.dmg
Checksumming Protective Master Boot Record (MBR : 0)…
Protective Master Boot Record (MBR :: verified CRC32 $8F1E8252
Checksumming GPT Header (Primary GPT Header : 1)…
 GPT Header (Primary GPT Header : 1): verified CRC32 $8E30B936
Checksumming GPT Partition Data (Primary GPT Table : 2)…
GPT Partition Data (Primary GPT Tabl: verified CRC32 $4BE9D0B3
Checksumming  (Apple_Free : 3)…
                    (Apple_Free : 3): verified CRC32 $00000000
Checksumming disk image (Apple_HFS : 4)…
...........................................................................................................................................................................................................
          disk image (Apple_HFS : 4): verified CRC32 $B1D7232A
Checksumming  (Apple_Free : 5)…
                    (Apple_Free : 5): verified CRC32 $00000000
Checksumming GPT Partition Data (Backup GPT Table : 6)…
GPT Partition Data (Backup GPT Table: verified CRC32 $4BE9D0B3
Checksumming GPT Header (Backup GPT Header : 7)…
  GPT Header (Backup GPT Header : 7): verified CRC32 $3CB5F427
verified CRC32 $F778A42F
/dev/disk2          	GUID_partition_scheme
/dev/disk2s1        	Apple_HFS                      	/Volumes/Codex Installer
"disk2" ejected.
patch pattern2a not found; skipping
patch pattern2b not found; skipping
patched /Users/<name>/code/codex-intel/work/app-extract/.vite/build/main-CQwPb0Th.js

added 102 packages, and audited 103 packages in 15s

16 packages are looking for funding
  run `npm fund` for details

found 0 vulnerabilities
gyp info it worked if it ends with ok
gyp info using node-gyp@12.2.0
gyp info using node@24.11.0 | darwin | x64
gyp info find Python using Python version 3.14.2 found at "/usr/local/opt/python@3.14/bin/python3.14"

gyp info spawn /usr/local/opt/python@3.14/bin/python3.14
gyp info spawn args [
gyp info spawn args '/Users/<name>/code/codex-intel/work/rebuild/node_modules/node-gyp/gyp/gyp_main.py',
gyp info spawn args 'binding.gyp',
gyp info spawn args '-f',
gyp info spawn args 'make',
gyp info spawn args '-I',
gyp info spawn args '/Users/<name>/code/codex-intel/work/rebuild/node_modules/better-sqlite3/build/config.gypi',
gyp info spawn args '-I',
gyp info spawn args '/Users/<name>/code/codex-intel/work/rebuild/node_modules/node-gyp/addon.gypi',
gyp info spawn args '-I',
gyp info spawn args '/Users/<name>/Library/Caches/node-gyp/40.0.0/include/node/common.gypi',
gyp info spawn args '-Dlibrary=shared_library',
gyp info spawn args '-Dvisibility=default',
gyp info spawn args '-Dnode_root_dir=/Users/<name>/Library/Caches/node-gyp/40.0.0',
gyp info spawn args '-Dnode_gyp_dir=/Users/<name>/code/codex-intel/work/rebuild/node_modules/node-gyp',
gyp info spawn args '-Dnode_lib_file=/Users/<name>/Library/Caches/node-gyp/40.0.0/<(target_arch)/node.lib',
gyp info spawn args '-Dmodule_root_dir=/Users/<name>/code/codex-intel/work/rebuild/node_modules/better-sqlite3',
gyp info spawn args '-Dnode_engine=v8',
gyp info spawn args '--depth=.',
gyp info spawn args '--no-parallel',
gyp info spawn args '--generator-output',
gyp info spawn args 'build',
gyp info spawn args '-Goutput_dir=.'
gyp info spawn args ]
gyp info spawn make
gyp info spawn args [ 'BUILDTYPE=Release', '-C', 'build' ]
  TOUCH 4292fa9a667d77b27488aa109b010a85bce8e4e7a1c7aa0370cea902395c3866.intermediate
  ACTION deps_sqlite3_gyp_locate_sqlite3_target_copy_builtin_sqlite3 4292fa9a667d77b27488aa109b010a85bce8e4e7a1c7aa0370cea902395c3866.intermediate
  TOUCH Release/obj.target/deps/locate_sqlite3.stamp
  CC(target) Release/obj.target/sqlite3/gen/sqlite3/sqlite3.o
  LIBTOOL-STATIC Release/sqlite3.a
  CXX(target) Release/obj.target/better_sqlite3/src/better_sqlite3.o
../src/better_sqlite3.cpp:48:1: warning: cast from 'void (*)(v8::Local<v8::Object>, v8::Local<v8::Value>, v8::Local<v8::Context>)' to 'node::addon_context_register_func' (aka 'void (*)(v8::Local<v8::Object>, v8::Local<v8::Value>, v8::Local<v8::Context>, void *)') converts to incompatible function type [-Wcast-function-type-mismatch]
   48 | NODE_MODULE_INIT(/* exports, context */) {
      | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Users/<name>/Library/Caches/node-gyp/40.0.0/include/node/node.h:1355:3: note: expanded from macro 'NODE_MODULE_INIT'
 1355 |   NODE_MODULE_CONTEXT_AWARE(NODE_GYP_MODULE_NAME,                     \
      |   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 1356 |                             NODE_MODULE_INITIALIZER)                  \
      |                             ~~~~~~~~~~~~~~~~~~~~~~~~
/Users/<name>/Library/Caches/node-gyp/40.0.0/include/node/node.h:1324:3: note: expanded from macro 'NODE_MODULE_CONTEXT_AWARE'
 1324 |   NODE_MODULE_CONTEXT_AWARE_X(modname, regfunc, NULL, 0)
      |   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Users/<name>/Library/Caches/node-gyp/40.0.0/include/node/node.h:1306:7: note: expanded from macro 'NODE_MODULE_CONTEXT_AWARE_X'
 1306 |       (node::addon_context_register_func) (regfunc),                  \
      |       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
1 warning generated.
  SOLINK_MODULE(target) Release/better_sqlite3.node
  CC(target) Release/obj.target/test_extension/deps/test_extension.o
  SOLINK_MODULE(target) Release/test_extension.node
rm 4292fa9a667d77b27488aa109b010a85bce8e4e7a1c7aa0370cea902395c3866.intermediate
gyp info ok
gyp info it worked if it ends with ok
gyp info using node-gyp@12.2.0
gyp info using node@24.11.0 | darwin | x64
gyp info find Python using Python version 3.14.2 found at "/usr/local/opt/python@3.14/bin/python3.14"

gyp info spawn /usr/local/opt/python@3.14/bin/python3.14
gyp info spawn args [
gyp info spawn args '/Users/<name>/code/codex-intel/work/rebuild/node_modules/node-gyp/gyp/gyp_main.py',
gyp info spawn args 'binding.gyp',
gyp info spawn args '-f',
gyp info spawn args 'make',
gyp info spawn args '-I',
gyp info spawn args '/Users/<name>/code/codex-intel/work/rebuild/node_modules/node-pty/build/config.gypi',
gyp info spawn args '-I',
gyp info spawn args '/Users/<name>/code/codex-intel/work/rebuild/node_modules/node-gyp/addon.gypi',
gyp info spawn args '-I',
gyp info spawn args '/Users/<name>/Library/Caches/node-gyp/40.0.0/include/node/common.gypi',
gyp info spawn args '-Dlibrary=shared_library',
gyp info spawn args '-Dvisibility=default',
gyp info spawn args '-Dnode_root_dir=/Users/<name>/Library/Caches/node-gyp/40.0.0',
gyp info spawn args '-Dnode_gyp_dir=/Users/<name>/code/codex-intel/work/rebuild/node_modules/node-gyp',
gyp info spawn args '-Dnode_lib_file=/Users/<name>/Library/Caches/node-gyp/40.0.0/<(target_arch)/node.lib',
gyp info spawn args '-Dmodule_root_dir=/Users/<name>/code/codex-intel/work/rebuild/node_modules/node-pty',
gyp info spawn args '-Dnode_engine=v8',
gyp info spawn args '--depth=.',
gyp info spawn args '--no-parallel',
gyp info spawn args '--generator-output',
gyp info spawn args 'build',
gyp info spawn args '-Goutput_dir=.'
gyp info spawn args ]
gyp info spawn make
gyp info spawn args [ 'BUILDTYPE=Release', '-C', 'build' ]
  TOUCH Release/obj.target/../node-addon-api/node_addon_api_except.stamp
  CXX(target) Release/obj.target/pty/src/unix/pty.o
../src/unix/pty.cc:139:30: warning: missing field 'filter' initializer [-Wmissing-field-initializers]
  139 |     struct kevent change = {0};
      |                              ^
../src/unix/pty.cc:159:31: warning: missing field 'filter' initializer [-Wmissing-field-initializers]
  159 |       struct kevent event = {0};
      |                               ^
2 warnings generated.
  SOLINK_MODULE(target) Release/pty.node
  CXX(target) Release/obj.target/spawn-helper/src/unix/spawn-helper.o
  LINK(target) Release/spawn-helper
gyp info ok
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
100  113M  100  113M    0     0  6362k      0  0:00:18  0:00:18 --:--:-- 5374k
Done: /Users/<name>/code/codex-intel/codex-app/Codex.app
```

</details>

After
<details>

```
➜  codex-intel git:(main) ./install.sh ~/Downloads/Codex.dmg
Checksumming Protective Master Boot Record (MBR : 0)…
Protective Master Boot Record (MBR :: verified CRC32 $8F1E8252
Checksumming GPT Header (Primary GPT Header : 1)…
 GPT Header (Primary GPT Header : 1): verified CRC32 $8E30B936
Checksumming GPT Partition Data (Primary GPT Table : 2)…
GPT Partition Data (Primary GPT Tabl: verified CRC32 $4BE9D0B3
Checksumming  (Apple_Free : 3)…
                    (Apple_Free : 3): verified CRC32 $00000000
Checksumming disk image (Apple_HFS : 4)…
...........................................................................................................................................................................................................
          disk image (Apple_HFS : 4): verified CRC32 $B1D7232A
Checksumming  (Apple_Free : 5)…
                    (Apple_Free : 5): verified CRC32 $00000000
Checksumming GPT Partition Data (Backup GPT Table : 6)…
GPT Partition Data (Backup GPT Table: verified CRC32 $4BE9D0B3
Checksumming GPT Header (Backup GPT Header : 7)…
  GPT Header (Backup GPT Header : 7): verified CRC32 $3CB5F427
verified CRC32 $F778A42F
/dev/disk2          	GUID_partition_scheme
/dev/disk2s1        	Apple_HFS                      	/Volumes/Codex Installer
"disk2" ejected.
patch pattern2a not found; skipping
patch pattern2b not found; skipping
patched /Users/<name>/code/codex-intel/work/app-extract/.vite/build/main-CQwPb0Th.js

added 102 packages, and audited 103 packages in 5s

16 packages are looking for funding
  run `npm fund` for details

found 0 vulnerabilities
Rebuilding better-sqlite3 for Electron x64...
Note: compiler warnings from upstream native modules are expected and non-fatal.
Streaming disabled; full output is written to /Users/<name>/code/codex-intel/work/logs/rebuild-better-sqlite3.log.
Rebuild OK: better-sqlite3 (1 warning line(s)). Log: /Users/<name>/code/codex-intel/work/logs/rebuild-better-sqlite3.log
Rebuilding node-pty for Electron x64...
Note: compiler warnings from upstream native modules are expected and non-fatal.
Streaming disabled; full output is written to /Users/<name>/code/codex-intel/work/logs/rebuild-node-pty.log.
Rebuild OK: node-pty (2 warning line(s)). Log: /Users/<name>/code/codex-intel/work/logs/rebuild-node-pty.log
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
100  113M  100  113M    0     0  5365k      0  0:00:21  0:00:21 --:--:-- 5739k
Done: /Users/<name>/code/codex-intel/codex-app/Codex.app
```

</details>

## Testing
- `bash -n install.sh`
- `./install.sh --help`

## Behavioral effect
- default installs now show clean high-level rebuild status instead of full compiler streams
- full diagnostics remain available in logs and with `-v` when detailed troubleshooting is needed
