### PR TITLE
feat(installer): support beta app bundles (include remote connection)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ Thanks for helping improve `codex-intel` - the Intel macOS port of [Codex App](h
 
 ## Scope
 
-This repo provides a local installer that converts an official Codex DMG into an Intel-compatible Electron app bundle.  
+This repo provides a local installer that converts an official Codex app bundle or DMG into an Intel-compatible Electron app bundle.  
 We do not distribute OpenAI DMGs or app binaries in this repository.
 
 ## What To Contribute
@@ -17,8 +17,8 @@ We do not distribute OpenAI DMGs or app binaries in this repository.
 
 ## Development
 
-- Run `./install.sh /path/to/Codex.dmg` on Intel macOS.
-- Validate by launching `./codex-app/Codex.app/Contents/MacOS/Electron --no-sandbox`.
+- Run `./install.sh /path/to/Codex*.app` or `./install.sh /path/to/Codex*.dmg` on an Intel Mac
+- Test by launching the generated app bundle under `./codex-app/`, for example `./codex-app/Codex.app/Contents/MacOS/Electron --no-sandbox`
 - Keep changes focused and easy to review.
 
 ## Issue Labels And Triage
@@ -62,4 +62,4 @@ Repository workflows implement this policy:
 - Include validation steps/output when possible.
 - Keep commits and PR scope tight.
 - Use Conventional Commits style for commit messages (for example: `fix(installer): guard SDK path detection`).
-- Do not include built artifacts, DMGs, or `Codex.app` outputs.
+- Do not include built artifacts, DMGs, or generated app bundles in PRs.

--- a/README.md
+++ b/README.md
@@ -90,6 +90,32 @@ unzip 'Codex (Beta)-darwin-arm64-26.317.21539.zip'
 ./install.sh './Codex (Beta).app'
 ```
 
+## Codex Automation
+
+If you use Codex Automations, you can save the beta refresh workflow as a scheduled task for this repo.
+
+Suggested setup:
+
+- workspace: `codex-intel`
+- schedule: weekdays at `9:00 AM`
+- model: `GPT-5.4`
+- title: `Update Codex Intel Binary`
+
+Suggested prompt:
+
+```text
+Help me take a look if there's a new beta release for the codex, download, and convert them so we can update our build.
+```
+
+This works well as a recurring repo maintenance task:
+
+- checks whether a newer Codex Beta build exists
+- downloads the current Beta app bundle zip
+- runs the local conversion flow in this repo
+- lets you review the resulting build/logs before committing any repo changes
+
+For manual installs, `install.sh` remains the source of truth.
+
 ## Usage
 
 The installer creates:

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 ![GitHub stars](https://img.shields.io/github/stars/Sancerio/codex-intel?style=flat)
 ![GitHub license](https://img.shields.io/github/license/Sancerio/codex-intel)
 
-Run OpenAI Codex Desktop on Intel macOS by converting the official macOS DMG into an x86_64 Electron app bundle.
+Run OpenAI Codex Desktop on Intel macOS by converting the official macOS app bundle or DMG into an x86_64 Electron app bundle. Stable and Beta builds are both supported.
 
 > This is an unofficial community project. Codex Desktop is a product of OpenAI.
 
@@ -14,12 +14,12 @@ Learn more about Codex: https://openai.com/codex/
 
 The installer:
 
-1. Extracts the macOS `.dmg`
+1. Takes a local `.app` bundle or extracts the macOS `.dmg`
 2. Pulls out `app.asar` (the Electron app)
 3. Rebuilds native modules (`node-pty`, `better-sqlite3`) for Electron x64
 4. Disables macOS‑only Sparkle auto‑update
 5. Downloads Electron v40 for darwin‑x64
-6. Repackages everything into a runnable `Codex.app`
+6. Repackages everything into a runnable app bundle with the same name as the original DMG app, such as `Codex.app` or `Codex (Beta).app`
 7. Applies a small patch so it doesn’t try to connect to a Vite dev server
 
 ## Prerequisites
@@ -44,13 +44,19 @@ npm i -g @openai/codex
 
 ## Installation
 
-### Option A: Provide your own DMG
+### Option A: Provide your own app bundle or DMG
 
 ```bash
 git clone https://github.com/<your-user>/codex-intel.git
 cd codex-intel
 chmod +x install.sh
-./install.sh /path/to/Codex.dmg
+./install.sh /path/to/Codex*.app
+```
+
+Or:
+
+```bash
+./install.sh /path/to/Codex*.dmg
 ```
 
 Verbose native rebuild output:
@@ -64,7 +70,7 @@ Verbose native rebuild output:
 If you have the DMG URL, you can pass it directly:
 
 ```bash
-./install.sh https://example.com/Codex.dmg
+./install.sh https://example.com/Codex*.dmg
 ```
 
 ## Usage
@@ -72,7 +78,7 @@ If you have the DMG URL, you can pass it directly:
 The installer creates:
 
 ```
-./codex-app/Codex.app
+./codex-app/<original app name>.app
 ```
 
 Launch it from Finder or:
@@ -81,11 +87,50 @@ Launch it from Finder or:
 ./codex-app/Codex.app/Contents/MacOS/Electron --no-sandbox
 ```
 
+For Beta builds, that path is typically:
+
+```bash
+./codex-app/Codex\ \(Beta\).app/Contents/MacOS/Electron --no-sandbox
+```
+
 Or use the helper script:
 
 ```bash
 ./start.sh
 ```
+
+## Performance (Intel Fan Noise / Idle Heat)
+
+This repo now applies a low-power window patch during `install.sh`:
+
+- forces opaque windows
+- disables liquid-glass effects
+- applies an aggressive renderer performance patch:
+  - disables renderer Sentry init
+  - bypasses Shiki highlight provider wrapper
+  - disables non-essential telemetry/notification hooks
+
+This reduces idle GPU load on many Intel Macs.
+
+Tradeoffs in aggressive mode:
+
+- desktop notifications/badge updates may be reduced
+- some telemetry diagnostics are disabled
+- code highlighting behavior may be simpler in chat output
+
+If you already built an app in `codex-app/`, patch it in place without reinstalling:
+
+```bash
+./optimize-power.sh
+```
+
+Optional custom app path:
+
+```bash
+./optimize-power.sh /path/to/Codex*.app
+```
+
+`./start.sh` launches the newest app bundle under `codex-app/`, so a fresh Beta install will be picked automatically even if older stable bundles are still present.
 
 ## Notes
 

--- a/README.md
+++ b/README.md
@@ -73,6 +73,19 @@ If you have the DMG URL, you can pass it directly:
 ./install.sh https://example.com/Codex*.dmg
 ```
 
+### Option C: Use the current Beta app bundle zip
+
+The current Beta desktop build is available here:
+
+[Codex (Beta) darwin-arm64 26.311.30926](https://persistent.oaistatic.com/codex-app-beta/Codex%20(Beta)-darwin-arm64-26.311.30926.zip)
+
+Because this download is a `.zip` containing `Codex (Beta).app`, unzip it first, then point `install.sh` at the extracted app bundle:
+
+```bash
+unzip 'Codex (Beta)-darwin-arm64-26.311.30926.zip'
+./install.sh './Codex (Beta).app'
+```
+
 ## Usage
 
 The installer creates:

--- a/README.md
+++ b/README.md
@@ -75,14 +75,18 @@ If you have the DMG URL, you can pass it directly:
 
 ### Option C: Use the current Beta app bundle zip
 
-The current Beta desktop build is available here:
+The current Beta desktop build is listed in the public beta appcast:
 
-[Codex (Beta) darwin-arm64 26.311.30926](https://persistent.oaistatic.com/codex-app-beta/Codex%20(Beta)-darwin-arm64-26.311.30926.zip)
+https://persistent.oaistatic.com/codex-app-beta/appcast.xml
+
+Current entry:
+
+[Codex (Beta) darwin-arm64 26.317.21539](https://persistent.oaistatic.com/codex-app-beta/Codex%20(Beta)-darwin-arm64-26.317.21539.zip)
 
 Because this download is a `.zip` containing `Codex (Beta).app`, unzip it first, then point `install.sh` at the extracted app bundle:
 
 ```bash
-unzip 'Codex (Beta)-darwin-arm64-26.311.30926.zip'
+unzip 'Codex (Beta)-darwin-arm64-26.317.21539.zip'
 ./install.sh './Codex (Beta).app'
 ```
 

--- a/install.sh
+++ b/install.sh
@@ -4,16 +4,26 @@ set -euo pipefail
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 WORK="$ROOT/work"
 OUT="$ROOT/codex-app"
+SYSTEM_APPS_DIR="/Applications"
 ELECTRON_VERSION="40.0.0"
 ELECTRON_ZIP="electron-v${ELECTRON_VERSION}-darwin-x64.zip"
 ELECTRON_URL="https://github.com/electron/electron/releases/download/v${ELECTRON_VERSION}/${ELECTRON_ZIP}"
-
+WORK_APP_PATH=""
+OUT_APP_PATH=""
+SYSTEM_APP_PATH=""
+APP_BUNDLE_NAME=""
+APP_DISPLAY_NAME=""
+APP_PLIST_NAME=""
+APP_BUNDLE_IDENTIFIER=""
+APP_VERSION=""
+APP_BUILD_VERSION=""
 NATIVE_REBUILD_VERBOSE="${NATIVE_REBUILD_VERBOSE:-0}"
-DMG_SRC=""
+SOURCE_INPUT=""
 usage() {
   cat <<EOF
-Usage: $0 [-h|--help] [-v|--verbose] /path/to/Codex.dmg
-       $0 [-h|--help] [-v|--verbose] https://.../Codex.dmg
+Usage: $0 [-h|--help] [-v|--verbose] /path/to/Codex*.app
+       $0 [-h|--help] [-v|--verbose] /path/to/Codex*.dmg
+       $0 [-h|--help] [-v|--verbose] https://.../Codex*.dmg
 
 Options:
   -h, --help      Show this help message and exit.
@@ -42,31 +52,31 @@ while [[ $# -gt 0 ]]; do
       exit 1
       ;;
     *)
-      if [[ -n "$DMG_SRC" ]]; then
-        echo "Error: multiple DMG sources provided."
+      if [[ -n "$SOURCE_INPUT" ]]; then
+        echo "Error: multiple sources provided."
         usage
         exit 1
       fi
-      DMG_SRC="$1"
+      SOURCE_INPUT="$1"
       shift
       ;;
   esac
 done
 
-if [[ -z "$DMG_SRC" && $# -gt 0 ]]; then
+if [[ -z "$SOURCE_INPUT" && $# -gt 0 ]]; then
   if [[ $# -gt 1 ]]; then
-    echo "Error: multiple DMG sources provided."
+    echo "Error: multiple sources provided."
     usage
     exit 1
   fi
-  DMG_SRC="$1"
-elif [[ -n "$DMG_SRC" && $# -gt 0 ]]; then
-  echo "Error: multiple DMG sources provided."
+  SOURCE_INPUT="$1"
+elif [[ -n "$SOURCE_INPUT" && $# -gt 0 ]]; then
+  echo "Error: multiple sources provided."
   usage
   exit 1
 fi
 
-if [[ -z "$DMG_SRC" ]]; then
+if [[ -z "$SOURCE_INPUT" ]]; then
   usage
   exit 1
 fi
@@ -109,31 +119,92 @@ PY
 
   return 1
 }
+SESSION_DIR="$(mktemp -d "$WORK/install.XXXXXX")"
 
-# Fetch DMG
-DMG_PATH="$WORK/Codex.dmg"
-if [[ "$DMG_SRC" =~ ^https?:// ]]; then
+read_plist_key() {
+  local plist_path="$1"
+  local key="$2"
+  /usr/libexec/PlistBuddy -c "Print :$key" "$plist_path" 2>/dev/null || true
+}
+
+force_remove_path() {
+  local target_path="$1"
+  if [[ -e "$target_path" ]]; then
+    chmod -R u+w "$target_path" 2>/dev/null || true
+    rm -rf "$target_path"
+  fi
+}
+
+SOURCE_APP_PATH=""
+if [[ "$SOURCE_INPUT" =~ ^https?:// ]]; then
+  DMG_PATH="$SESSION_DIR/Codex.dmg"
   echo "Downloading DMG..."
-  curl -fL "$DMG_SRC" -o "$DMG_PATH"
+  curl -fL "$SOURCE_INPUT" -o "$DMG_PATH"
+elif [[ -d "$SOURCE_INPUT" && "$SOURCE_INPUT" == *.app ]]; then
+  SOURCE_APP_PATH="$(cd "$(dirname "$SOURCE_INPUT")" && pwd)/$(basename "$SOURCE_INPUT")"
 else
-  cp "$DMG_SRC" "$DMG_PATH"
+  DMG_PATH="$SESSION_DIR/Codex.dmg"
+  cp "$SOURCE_INPUT" "$DMG_PATH"
 fi
 
-# Mount DMG
-MOUNT_POINT="/Volumes/Codex Installer"
-if mount | grep -q "${MOUNT_POINT}"; then
-  hdiutil detach "$MOUNT_POINT" || true
-fi
-hdiutil attach "$DMG_PATH" -nobrowse -readonly
+if [[ -z "$SOURCE_APP_PATH" ]]; then
+  # Mount DMG
+  ATTACH_PLIST="$SESSION_DIR/attach.plist"
+  hdiutil attach "$DMG_PATH" -nobrowse -readonly -plist > "$ATTACH_PLIST"
+  MOUNT_POINT="$(python3 - "$ATTACH_PLIST" <<'PY'
+import plistlib
+import sys
 
-# Copy app bundle
-cp -R "$MOUNT_POINT/Codex.app" "$WORK/Codex.app"
-chmod -R u+w "$WORK/Codex.app"
-hdiutil detach "$MOUNT_POINT"
+with open(sys.argv[1], "rb") as fh:
+    data = plistlib.load(fh)
+
+for entity in data.get("system-entities", []):
+    mount_point = entity.get("mount-point")
+    if mount_point:
+        print(mount_point)
+        break
+else:
+    raise SystemExit("unable to determine DMG mount point")
+PY
+)"
+
+  SOURCE_APP_PATH="$(find "$MOUNT_POINT" -maxdepth 1 -type d -name '*.app' -print | sort | head -n 1)"
+  if [[ -z "$SOURCE_APP_PATH" ]]; then
+    hdiutil detach "$MOUNT_POINT" || true
+    echo "Error: no .app bundle found at $MOUNT_POINT"
+    exit 1
+  fi
+fi
+
+APP_BUNDLE_NAME="$(basename "$SOURCE_APP_PATH")"
+WORK_APP_PATH="$SESSION_DIR/$APP_BUNDLE_NAME"
+OUT_APP_PATH="$OUT/$APP_BUNDLE_NAME"
+SYSTEM_APP_PATH="$SYSTEM_APPS_DIR/$APP_BUNDLE_NAME"
+
+force_remove_path "$WORK_APP_PATH"
+cp -R "$SOURCE_APP_PATH" "$WORK_APP_PATH"
+chmod -R u+w "$WORK_APP_PATH"
+if [[ -n "${MOUNT_POINT:-}" ]]; then
+  hdiutil detach "$MOUNT_POINT"
+fi
+
+SOURCE_INFO_PLIST="$WORK_APP_PATH/Contents/Info.plist"
+APP_DISPLAY_NAME="$(read_plist_key "$SOURCE_INFO_PLIST" "CFBundleDisplayName")"
+APP_PLIST_NAME="$(read_plist_key "$SOURCE_INFO_PLIST" "CFBundleName")"
+APP_BUNDLE_IDENTIFIER="$(read_plist_key "$SOURCE_INFO_PLIST" "CFBundleIdentifier")"
+APP_VERSION="$(read_plist_key "$SOURCE_INFO_PLIST" "CFBundleShortVersionString")"
+APP_BUILD_VERSION="$(read_plist_key "$SOURCE_INFO_PLIST" "CFBundleVersion")"
+
+if [[ -z "$APP_DISPLAY_NAME" ]]; then
+  APP_DISPLAY_NAME="${APP_BUNDLE_NAME%.app}"
+fi
+if [[ -z "$APP_PLIST_NAME" ]]; then
+  APP_PLIST_NAME="$APP_DISPLAY_NAME"
+fi
 
 # Extract app.asar
-ASAR_EXTRACT="$WORK/app-extract"
-rm -rf "$ASAR_EXTRACT"
+ASAR_EXTRACT="$SESSION_DIR/app-extract"
+force_remove_path "$ASAR_EXTRACT"
 mkdir -p "$ASAR_EXTRACT"
 
 ASAR_CMD="asar"
@@ -146,27 +217,63 @@ if ! command -v asar >/dev/null 2>&1; then
   ASAR_CMD="$ASAR_TOOLS/node_modules/.bin/asar"
 fi
 
-"$ASAR_CMD" extract "$WORK/Codex.app/Contents/Resources/app.asar" "$ASAR_EXTRACT"
+"$ASAR_CMD" extract "$WORK_APP_PATH/Contents/Resources/app.asar" "$ASAR_EXTRACT"
 
-# Patch main entry (avoid dev server; guard markAppQuitting)
-PATCH_LOG="$WORK/patch-main.log"
+# Patch main entry:
+# 1) avoid accidental dev-server loading in packaged mode
+# 2) guard markAppQuitting access
+# 3) force low-power window effects for Intel Macs (opaque windows, no liquid-glass)
+PATCH_LOG="$SESSION_DIR/patch-main.log"
 if ! python3 - <<PY 2>"$PATCH_LOG"
 from pathlib import Path
 import re
 
 build_dir = Path("$ASAR_EXTRACT/.vite/build")
-main_stub = build_dir / "main.js"
-if not main_stub.exists():
-    raise SystemExit(f"main.js not found at {main_stub}")
+def resolve_main_entry(build_path: Path) -> Path:
+    markers = (
+        "ELECTRON_RENDERER_URL",
+        "markAppQuitting",
+        "isOpaqueWindowsEnabled",
+        "getLiquidGlassSupport",
+        "electron-liquid-glass",
+    )
+    marker_candidates = [
+        *sorted(build_path.glob("main-*.js")),
+        *sorted(build_path.glob("bootstrap-*.js")),
+        *[candidate for candidate in (build_path / "main.js", build_path / "bootstrap.js") if candidate.exists()],
+    ]
+    for candidate in marker_candidates:
+        candidate_text = candidate.read_text()
+        if any(marker in candidate_text for marker in markers):
+            return candidate
 
-target = main_stub
-stub_text = main_stub.read_text()
-match = re.search(r'require\(["\']\./(main-[^"\']+\.js)["\']\)', stub_text)
-if match:
-    candidate = build_dir / match.group(1)
-    if not candidate.exists():
-        raise SystemExit(f"referenced main entry not found: {candidate}")
-    target = candidate
+    target = None
+    for stub_name in ("main.js", "bootstrap.js"):
+        stub = build_path / stub_name
+        if stub.exists():
+            target = stub
+            break
+    if target is None:
+        raise SystemExit(f"main entry stub not found in {build_path}")
+
+    seen = set()
+    while True:
+        target_key = str(target)
+        if target_key in seen:
+            return target
+        seen.add(target_key)
+
+        stub_text = target.read_text()
+        match = re.search(r'require\(["\']\./((?:main|bootstrap)-[^"\']+\.js)["\']\)', stub_text)
+        if not match:
+            return target
+
+        candidate = build_path / match.group(1)
+        if not candidate.exists():
+            raise SystemExit(f"referenced main entry not found: {candidate}")
+        target = candidate
+
+target = resolve_main_entry(build_dir)
 
 text = target.read_text()
 
@@ -221,23 +328,102 @@ if m3:
 else:
     print("patch pattern2b not found; skipping")
 
+def patch_low_power_visual_effects(src: str) -> str:
+    updated = src
+
+    old_opaque = "isOpaqueWindowsEnabled(t){return this.options.getGlobalStateForHost(t).get(Wv.OPAQUE_WINDOWS)===!0}"
+    new_opaque = "isOpaqueWindowsEnabled(t){return!0}"
+    if old_opaque in updated:
+        updated = updated.replace(old_opaque, new_opaque, 1)
+    else:
+        updated = re.sub(
+            r"isOpaqueWindowsEnabled\([^)]*\)\{return[^}]+\}",
+            "isOpaqueWindowsEnabled(t){return!0}",
+            updated,
+            count=1,
+        )
+
+    old_glass = (
+        'async getLiquidGlassSupport(){if(this.liquidGlassSupport!=null)return this.liquidGlassSupport;'
+        'if(process.platform!=="darwin")return this.liquidGlassSupport=!1,!1;try{const n='
+        '(await import("electron-liquid-glass")).default.isGlassSupported?.()??!1;'
+        'return this.liquidGlassSupport=n,this.liquidGlassSupport}catch{return this.liquidGlassSupport=!1,!1}}'
+    )
+    new_glass = "async getLiquidGlassSupport(){return this.liquidGlassSupport=!1,!1}"
+    if old_glass in updated:
+        updated = updated.replace(old_glass, new_glass, 1)
+    else:
+        updated = re.sub(
+            r'async getLiquidGlassSupport\(\)\{if\(this\.liquidGlassSupport!=null\)return this\.liquidGlassSupport;'
+            r'if\(process\.platform!=="darwin"\)return this\.liquidGlassSupport=!1,!1;try\{const [^}]+'
+            r'return this\.liquidGlassSupport=n,this\.liquidGlassSupport\}catch\{return this\.liquidGlassSupport=!1,!1\}\}',
+            new_glass,
+            updated,
+            count=1,
+        )
+
+    if updated == src:
+        print("low-power patch patterns not found; skipping")
+    return updated
+
+text = patch_low_power_visual_effects(text)
+
 target.write_text(text)
 print(f"patched {target}")
+
+assets_dir = Path("$ASAR_EXTRACT/webview/assets")
+index_candidates = sorted(assets_dir.glob("index-*.js"))
+if not index_candidates:
+    raise SystemExit(f"webview index bundle not found in {assets_dir}")
+
+index_target = index_candidates[0]
+renderer = index_target.read_text()
+original_renderer = renderer
+
+def patch_renderer_performance(src: str) -> str:
+    out = src
+
+    # Disable Shiki provider wrapper to reduce renderer CPU during streaming updates.
+    marker_start = out.find("function W8n(t){")
+    marker_end = out.find("function V8n()", marker_start)
+    if marker_start != -1 and marker_end != -1:
+        out = out[:marker_start] + "function W8n(t){const{children:e}=t;return e}" + out[marker_end:]
+
+    # Disable renderer Sentry init and selected non-essential hooks.
+    out = out.replace("I7n();", "", 1)
+    for old in (
+        "h.jsx(P7n,{})",  # telemetry user wiring
+        "h.jsx(B8n,{})",  # app-open/app-close analytics event
+        "h.jsx(d7n,{})",  # desktop notifications lifecycle
+        "h.jsx(t7n,{})",  # badge count updates
+        "h.jsx(b7n,{})",  # post-turn diff-comment extraction
+    ):
+        out = out.replace(old, "null", 1)
+
+    return out
+
+renderer = patch_renderer_performance(renderer)
+if renderer == original_renderer:
+    print("renderer performance patch patterns not found; skipping")
+else:
+    index_target.write_text(renderer)
+    print(f"patched {index_target}")
 PY
 then
   echo "Error: automatic patching failed for this Codex build."
   if command -v codex >/dev/null 2>&1; then
     cat <<EOF
-Fallback: use Codex CLI to adapt install.sh patch logic for this specific DMG build, then rerun.
+Fallback: use Codex CLI to adapt install.sh patch logic for this specific Codex build, then rerun.
 
 Run:
 codex exec -C "$ROOT" --sandbox workspace-write 'Update install.sh patch logic so it still patches the current .vite/build main entry from this DMG. Keep behavior the same except:
 1) only attempt dev-server URL logic when process.env.ELECTRON_RENDERER_URL is set
 2) guard any markAppQuitting() call with a typeof/object existence check.
+3) force low-power visuals by making isOpaqueWindowsEnabled() return true and getLiquidGlassSupport() return false.
 Do not change unrelated installer behavior.'
 
 Then rerun:
-./install.sh "$DMG_SRC"
+./install.sh "$SOURCE_INPUT"
 EOF
   else
     echo "Install Codex CLI for guided fallback patching: npm i -g @openai/codex"
@@ -248,8 +434,8 @@ EOF
 fi
 
 # Rebuild native modules for Electron x64
-REBUILD="$WORK/rebuild"
-rm -rf "$REBUILD"
+REBUILD="$SESSION_DIR/rebuild"
+force_remove_path "$REBUILD"
 mkdir -p "$REBUILD"
 cd "$REBUILD"
 unset npm_config_runtime npm_config_target npm_config_arch npm_config_disturl
@@ -337,31 +523,31 @@ truncate -s 0 "$ASAR_EXTRACT/native/sparkle.node" || true
 
 # Pack asar (unpack native .node files)
 cd "$ROOT"
-"$ASAR_CMD" pack "$ASAR_EXTRACT" "$WORK/Codex.app/Contents/Resources/app.asar" --unpack "**/*.node"
+"$ASAR_CMD" pack "$ASAR_EXTRACT" "$WORK_APP_PATH/Contents/Resources/app.asar" --unpack "**/*.node"
 
 # Prepare Electron x64 bundle
-ELECTRON_DIR="$WORK/electron"
-rm -rf "$ELECTRON_DIR"
+ELECTRON_DIR="$SESSION_DIR/electron"
+force_remove_path "$ELECTRON_DIR"
 mkdir -p "$ELECTRON_DIR"
 cd "$ELECTRON_DIR"
 curl -fL "$ELECTRON_URL" -o electron.zip
 unzip -q electron.zip
 
 # Build final app
-rm -rf "$OUT/Codex.app"
-cp -R "$ELECTRON_DIR/Electron.app" "$OUT/Codex.app"
+force_remove_path "$OUT_APP_PATH"
+cp -R "$ELECTRON_DIR/Electron.app" "$OUT_APP_PATH"
 
 # Replace resources
-cp "$WORK/Codex.app/Contents/Resources/app.asar" "$OUT/Codex.app/Contents/Resources/app.asar"
-cp -R "$WORK/Codex.app/Contents/Resources/app.asar.unpacked" "$OUT/Codex.app/Contents/Resources/"
-cp -R "$WORK/Codex.app/Contents/Resources/native" "$OUT/Codex.app/Contents/Resources/"
+cp "$WORK_APP_PATH/Contents/Resources/app.asar" "$OUT_APP_PATH/Contents/Resources/app.asar"
+cp -R "$WORK_APP_PATH/Contents/Resources/app.asar.unpacked" "$OUT_APP_PATH/Contents/Resources/"
+cp -R "$WORK_APP_PATH/Contents/Resources/native" "$OUT_APP_PATH/Contents/Resources/"
 
 # Copy Codex CLI (optional)
 CODEX_CMD="$(type -P codex 2>/dev/null || true)"
 if [[ -n "$CODEX_CMD" && -x "$CODEX_CMD" ]]; then
   # Resolve to a concrete x86_64 binary when PATH points to a launcher script.
   if CODEX_BIN="$(resolve_x64_codex_cli "$CODEX_CMD")"; then
-    if ! install -m 755 "$CODEX_BIN" "$OUT/Codex.app/Contents/Resources/codex"; then
+    if ! install -m 755 "$CODEX_BIN" "$OUT_APP_PATH/Contents/Resources/codex"; then
       echo "Warning: failed to copy x86_64 Codex CLI into app bundle from $CODEX_BIN (continuing)."
     fi
   else
@@ -372,7 +558,24 @@ else
 fi
 
 # Icon + Info.plist
-cp "$WORK/Codex.app/Contents/Resources/electron.icns" "$OUT/Codex.app/Contents/Resources/electron.icns"
-/usr/libexec/PlistBuddy -c "Set :CFBundleDisplayName Codex" -c "Set :CFBundleName Codex" "$OUT/Codex.app/Contents/Info.plist"
+cp "$WORK_APP_PATH/Contents/Resources/electron.icns" "$OUT_APP_PATH/Contents/Resources/electron.icns"
+plutil -replace CFBundleDisplayName -string "$APP_DISPLAY_NAME" "$OUT_APP_PATH/Contents/Info.plist"
+plutil -replace CFBundleName -string "$APP_PLIST_NAME" "$OUT_APP_PATH/Contents/Info.plist"
+if [[ -n "$APP_BUNDLE_IDENTIFIER" ]]; then
+  plutil -replace CFBundleIdentifier -string "$APP_BUNDLE_IDENTIFIER" "$OUT_APP_PATH/Contents/Info.plist"
+fi
+if [[ -n "$APP_VERSION" ]]; then
+  plutil -replace CFBundleShortVersionString -string "$APP_VERSION" "$OUT_APP_PATH/Contents/Info.plist"
+fi
+if [[ -n "$APP_BUILD_VERSION" ]]; then
+  plutil -replace CFBundleVersion -string "$APP_BUILD_VERSION" "$OUT_APP_PATH/Contents/Info.plist"
+fi
 
-echo "Done: $OUT/Codex.app"
+# Install to /Applications
+mkdir -p "$SYSTEM_APPS_DIR"
+if [[ -d "$SYSTEM_APP_PATH" ]]; then
+  force_remove_path "$SYSTEM_APP_PATH"
+fi
+cp -R "$OUT_APP_PATH" "$SYSTEM_APP_PATH"
+
+echo "Done: $SYSTEM_APP_PATH"

--- a/install.sh
+++ b/install.sh
@@ -17,6 +17,7 @@ APP_PLIST_NAME=""
 APP_BUNDLE_IDENTIFIER=""
 APP_VERSION=""
 APP_BUILD_VERSION=""
+MOUNT_POINT=""
 NATIVE_REBUILD_VERBOSE="${NATIVE_REBUILD_VERBOSE:-0}"
 SOURCE_INPUT=""
 normalize_source_input_path() {
@@ -138,6 +139,18 @@ PY
 }
 SESSION_DIR="$(mktemp -d "$WORK/install.XXXXXX")"
 
+cleanup() {
+  if [[ -n "$MOUNT_POINT" ]]; then
+    hdiutil detach "$MOUNT_POINT" >/dev/null 2>&1 || true
+  fi
+
+  if [[ -n "$SESSION_DIR" && -d "$SESSION_DIR" ]]; then
+    rm -rf "$SESSION_DIR"
+  fi
+}
+
+trap cleanup EXIT
+
 read_plist_key() {
   local plist_path="$1"
   local key="$2"
@@ -153,22 +166,39 @@ force_remove_path() {
 }
 
 install_to_system_applications() {
+  local staged_app_path="$SYSTEM_APPS_DIR/.${APP_BUNDLE_NAME}.staged.$$"
+  local previous_app_path="$SYSTEM_APPS_DIR/.${APP_BUNDLE_NAME}.previous.$$"
+
   if ! mkdir -p "$SYSTEM_APPS_DIR" 2>/dev/null; then
     echo "Warning: unable to create $SYSTEM_APPS_DIR; leaving app at $OUT_APP_PATH"
     return 1
   fi
 
-  if [[ -e "$SYSTEM_APP_PATH" ]] && ! force_remove_path "$SYSTEM_APP_PATH"; then
-    echo "Warning: unable to replace existing app at $SYSTEM_APP_PATH; leaving app at $OUT_APP_PATH"
+  force_remove_path "$staged_app_path" || true
+  force_remove_path "$previous_app_path" || true
+
+  if ! cp -R "$OUT_APP_PATH" "$staged_app_path" 2>/dev/null; then
+    force_remove_path "$staged_app_path" || true
+    echo "Warning: unable to stage app at $SYSTEM_APPS_DIR; leaving app at $OUT_APP_PATH"
     return 1
   fi
 
-  if ! cp -R "$OUT_APP_PATH" "$SYSTEM_APP_PATH" 2>/dev/null; then
-    force_remove_path "$SYSTEM_APP_PATH" || true
+  if [[ -e "$SYSTEM_APP_PATH" ]] && ! mv "$SYSTEM_APP_PATH" "$previous_app_path" 2>/dev/null; then
+    force_remove_path "$staged_app_path" || true
+    echo "Warning: unable to preserve existing app at $SYSTEM_APP_PATH; leaving app at $OUT_APP_PATH"
+    return 1
+  fi
+
+  if ! mv "$staged_app_path" "$SYSTEM_APP_PATH" 2>/dev/null; then
+    if [[ -e "$previous_app_path" ]]; then
+      mv "$previous_app_path" "$SYSTEM_APP_PATH" 2>/dev/null || true
+    fi
+    force_remove_path "$staged_app_path" || true
     echo "Warning: unable to copy app to $SYSTEM_APP_PATH; leaving app at $OUT_APP_PATH"
     return 1
   fi
 
+  force_remove_path "$previous_app_path" || true
   return 0
 }
 
@@ -207,8 +237,10 @@ PY
 
   SOURCE_APP_PATH="$(find "$MOUNT_POINT" -maxdepth 1 -type d -name '*.app' -print | sort | head -n 1)"
   if [[ -z "$SOURCE_APP_PATH" ]]; then
+    local_mount_point="$MOUNT_POINT"
     hdiutil detach "$MOUNT_POINT" || true
-    echo "Error: no .app bundle found at $MOUNT_POINT"
+    MOUNT_POINT=""
+    echo "Error: no .app bundle found at $local_mount_point"
     exit 1
   fi
 fi
@@ -221,8 +253,9 @@ SYSTEM_APP_PATH="$SYSTEM_APPS_DIR/$APP_BUNDLE_NAME"
 force_remove_path "$WORK_APP_PATH"
 cp -R "$SOURCE_APP_PATH" "$WORK_APP_PATH"
 chmod -R u+w "$WORK_APP_PATH"
-if [[ -n "${MOUNT_POINT:-}" ]]; then
+if [[ -n "$MOUNT_POINT" ]]; then
   hdiutil detach "$MOUNT_POINT"
+  MOUNT_POINT=""
 fi
 
 SOURCE_INFO_PLIST="$WORK_APP_PATH/Contents/Info.plist"

--- a/install.sh
+++ b/install.sh
@@ -19,6 +19,21 @@ APP_VERSION=""
 APP_BUILD_VERSION=""
 NATIVE_REBUILD_VERBOSE="${NATIVE_REBUILD_VERBOSE:-0}"
 SOURCE_INPUT=""
+normalize_source_input_path() {
+  local input_path="$1"
+
+  if [[ "$input_path" =~ ^https?:// ]]; then
+    printf '%s\n' "$input_path"
+    return
+  fi
+
+  while [[ "$input_path" == */ && "$input_path" != "/" ]]; do
+    input_path="${input_path%/}"
+  done
+
+  printf '%s\n' "$input_path"
+}
+
 usage() {
   cat <<EOF
 Usage: $0 [-h|--help] [-v|--verbose] /path/to/Codex*.app
@@ -81,6 +96,8 @@ if [[ -z "$SOURCE_INPUT" ]]; then
   exit 1
 fi
 
+SOURCE_INPUT="$(normalize_source_input_path "$SOURCE_INPUT")"
+
 mkdir -p "$WORK" "$OUT"
 LOG_DIR="$WORK/logs"
 mkdir -p "$LOG_DIR"
@@ -131,8 +148,28 @@ force_remove_path() {
   local target_path="$1"
   if [[ -e "$target_path" ]]; then
     chmod -R u+w "$target_path" 2>/dev/null || true
-    rm -rf "$target_path"
+    rm -rf "$target_path" 2>/dev/null || return 1
   fi
+}
+
+install_to_system_applications() {
+  if ! mkdir -p "$SYSTEM_APPS_DIR" 2>/dev/null; then
+    echo "Warning: unable to create $SYSTEM_APPS_DIR; leaving app at $OUT_APP_PATH"
+    return 1
+  fi
+
+  if [[ -e "$SYSTEM_APP_PATH" ]] && ! force_remove_path "$SYSTEM_APP_PATH"; then
+    echo "Warning: unable to replace existing app at $SYSTEM_APP_PATH; leaving app at $OUT_APP_PATH"
+    return 1
+  fi
+
+  if ! cp -R "$OUT_APP_PATH" "$SYSTEM_APP_PATH" 2>/dev/null; then
+    force_remove_path "$SYSTEM_APP_PATH" || true
+    echo "Warning: unable to copy app to $SYSTEM_APP_PATH; leaving app at $OUT_APP_PATH"
+    return 1
+  fi
+
+  return 0
 }
 
 SOURCE_APP_PATH=""
@@ -583,11 +620,9 @@ if [[ -n "$APP_BUILD_VERSION" ]]; then
   plutil -replace CFBundleVersion -string "$APP_BUILD_VERSION" "$OUT_APP_PATH/Contents/Info.plist"
 fi
 
-# Install to /Applications
-mkdir -p "$SYSTEM_APPS_DIR"
-if [[ -d "$SYSTEM_APP_PATH" ]]; then
-  force_remove_path "$SYSTEM_APP_PATH"
+# Install to /Applications when permitted.
+if install_to_system_applications; then
+  echo "Done: $SYSTEM_APP_PATH"
+else
+  echo "Done: $OUT_APP_PATH"
 fi
-cp -R "$OUT_APP_PATH" "$SYSTEM_APP_PATH"
-
-echo "Done: $SYSTEM_APP_PATH"

--- a/install.sh
+++ b/install.sh
@@ -368,6 +368,18 @@ def patch_low_power_visual_effects(src: str) -> str:
 
 text = patch_low_power_visual_effects(text)
 
+def patch_app_server_analytics_default(src: str) -> str:
+    updated, count = re.subn(
+        r'args:\["app-server","--analytics-default-enabled"\]',
+        'args:["app-server"]',
+        src,
+    )
+    if count == 0:
+        print("app-server analytics patch pattern not found; skipping")
+    return updated
+
+text = patch_app_server_analytics_default(text)
+
 target.write_text(text)
 print(f"patched {target}")
 

--- a/optimize-power.sh
+++ b/optimize-power.sh
@@ -1,0 +1,232 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+APP_DIR="$ROOT/codex-app"
+DEFAULT_APP_PATH="$APP_DIR/Codex.app"
+APP_PATH="${1:-$DEFAULT_APP_PATH}"
+OPTIMIZED_APP_PATH=""
+ASAR_PATH=""
+WORK="$ROOT/work/power-optimize"
+ASAR_EXTRACT="$WORK/app-extract"
+PATCH_LOG="$WORK/patch-power.log"
+
+select_latest_app_path() {
+  local app_root="$1"
+  local exclude_pattern="${2:-}"
+  local candidate=""
+  local selected=""
+  local selected_mtime=0
+  local candidate_mtime=0
+
+  while IFS= read -r -d '' candidate; do
+    if [[ -n "$exclude_pattern" && "$candidate" == $exclude_pattern ]]; then
+      continue
+    fi
+    candidate_mtime="$(stat -f '%m' "$candidate")" || continue
+    if [[ -z "$selected" || "$candidate_mtime" -gt "$selected_mtime" ]]; then
+      selected="$candidate"
+      selected_mtime="$candidate_mtime"
+    fi
+  done < <(find "$app_root" -maxdepth 1 -type d -name '*.app' -print0)
+
+  printf '%s' "$selected"
+}
+
+if [[ -z "${1:-}" && -d "$APP_DIR" && ! -d "$APP_PATH" ]]; then
+  APP_PATH="$(select_latest_app_path "$APP_DIR" '*-optimized.app')"
+fi
+
+if [[ ! -d "$APP_PATH" ]]; then
+  echo "App bundle not found at: ${APP_PATH:-$DEFAULT_APP_PATH}"
+  echo "Usage: $0 [/path/to/Codex*.app]"
+  exit 1
+fi
+
+OPTIMIZED_APP_PATH="${APP_PATH%.app}-optimized.app"
+
+resolve_asar_path() {
+  ASAR_PATH="$APP_PATH/Contents/Resources/app.asar"
+  if [[ ! -f "$ASAR_PATH" ]]; then
+    echo "app.asar not found at: $ASAR_PATH"
+    exit 1
+  fi
+}
+
+resolve_asar_path
+
+if [[ ! -w "$ASAR_PATH" ]]; then
+  if [[ -z "${1:-}" ]]; then
+    rm -rf "$OPTIMIZED_APP_PATH"
+    cp -R "$APP_PATH" "$OPTIMIZED_APP_PATH"
+    chmod -R u+w "$OPTIMIZED_APP_PATH"
+    APP_PATH="$OPTIMIZED_APP_PATH"
+    resolve_asar_path
+    echo "Created writable copy at: $APP_PATH"
+  else
+    echo "app.asar is not writable: $ASAR_PATH"
+    echo "Fix permissions or run without an argument to auto-create ${OPTIMIZED_APP_PATH##*/}."
+    exit 1
+  fi
+fi
+
+mkdir -p "$WORK"
+rm -rf "$ASAR_EXTRACT"
+mkdir -p "$ASAR_EXTRACT"
+
+ASAR_CMD="asar"
+if ! command -v asar >/dev/null 2>&1; then
+  ASAR_TOOLS="$ROOT/work/asar-tools"
+  mkdir -p "$ASAR_TOOLS"
+  if [[ ! -x "$ASAR_TOOLS/node_modules/.bin/asar" ]]; then
+    (cd "$ASAR_TOOLS" && npm init -y >/dev/null && npm i --no-save asar)
+  fi
+  ASAR_CMD="$ASAR_TOOLS/node_modules/.bin/asar"
+fi
+
+"$ASAR_CMD" extract "$ASAR_PATH" "$ASAR_EXTRACT"
+
+if ! python3 - <<PY 2>"$PATCH_LOG"
+from pathlib import Path
+import re
+
+build_dir = Path("$ASAR_EXTRACT/.vite/build")
+def resolve_main_entry(build_path: Path) -> Path:
+    markers = (
+        "ELECTRON_RENDERER_URL",
+        "markAppQuitting",
+        "isOpaqueWindowsEnabled",
+        "getLiquidGlassSupport",
+        "electron-liquid-glass",
+    )
+    marker_candidates = [
+        *sorted(build_path.glob("main-*.js")),
+        *sorted(build_path.glob("bootstrap-*.js")),
+        *[candidate for candidate in (build_path / "main.js", build_path / "bootstrap.js") if candidate.exists()],
+    ]
+    for candidate in marker_candidates:
+        candidate_text = candidate.read_text()
+        if any(marker in candidate_text for marker in markers):
+            return candidate
+
+    target = None
+    for stub_name in ("main.js", "bootstrap.js"):
+        stub = build_path / stub_name
+        if stub.exists():
+            target = stub
+            break
+    if target is None:
+        raise SystemExit(f"main entry stub not found in {build_path}")
+
+    seen = set()
+    while True:
+        target_key = str(target)
+        if target_key in seen:
+            return target
+        seen.add(target_key)
+
+        stub_text = target.read_text()
+        match = re.search(r'require\(["\']\./((?:main|bootstrap)-[^"\']+\.js)["\']\)', stub_text)
+        if not match:
+            return target
+
+        candidate = build_path / match.group(1)
+        if not candidate.exists():
+            raise SystemExit(f"referenced main entry not found: {candidate}")
+        target = candidate
+
+target = resolve_main_entry(build_dir)
+
+text = target.read_text()
+
+old_opaque = "isOpaqueWindowsEnabled(t){return this.options.getGlobalStateForHost(t).get(Wv.OPAQUE_WINDOWS)===!0}"
+new_opaque = "isOpaqueWindowsEnabled(t){return!0}"
+if old_opaque in text:
+    text = text.replace(old_opaque, new_opaque, 1)
+else:
+    text, count = re.subn(
+        r"isOpaqueWindowsEnabled\([^)]*\)\{return[^}]+\}",
+        "isOpaqueWindowsEnabled(t){return!0}",
+        text,
+        count=1,
+    )
+    if count == 0:
+        raise SystemExit("unable to patch isOpaqueWindowsEnabled in main bundle")
+
+old_glass = (
+    'async getLiquidGlassSupport(){if(this.liquidGlassSupport!=null)return this.liquidGlassSupport;'
+    'if(process.platform!=="darwin")return this.liquidGlassSupport=!1,!1;try{const n='
+    '(await import("electron-liquid-glass")).default.isGlassSupported?.()??!1;'
+    'return this.liquidGlassSupport=n,this.liquidGlassSupport}catch{return this.liquidGlassSupport=!1,!1}}'
+)
+new_glass = "async getLiquidGlassSupport(){return this.liquidGlassSupport=!1,!1}"
+if old_glass in text:
+    text = text.replace(old_glass, new_glass, 1)
+else:
+    text, count = re.subn(
+        r'async getLiquidGlassSupport\(\)\{if\(this\.liquidGlassSupport!=null\)return this\.liquidGlassSupport;'
+        r'if\(process\.platform!=="darwin"\)return this\.liquidGlassSupport=!1,!1;try\{const [^}]+'
+        r'return this\.liquidGlassSupport=n,this\.liquidGlassSupport\}catch\{return this\.liquidGlassSupport=!1,!1\}\}',
+        new_glass,
+        text,
+        count=1,
+    )
+    if count == 0:
+        raise SystemExit("unable to patch getLiquidGlassSupport in main bundle")
+
+target.write_text(text)
+print(f"patched {target}")
+
+assets_dir = Path("$ASAR_EXTRACT/webview/assets")
+index_candidates = sorted(assets_dir.glob("index-*.js"))
+if not index_candidates:
+    raise SystemExit(f"webview index bundle not found in {assets_dir}")
+
+index_target = index_candidates[0]
+renderer = index_target.read_text()
+original_renderer = renderer
+
+# Disable Shiki provider wrapper to reduce renderer CPU during streaming updates.
+marker_start = renderer.find("function W8n(t){")
+marker_end = renderer.find("function V8n()", marker_start)
+if marker_start != -1 and marker_end != -1:
+    renderer = (
+        renderer[:marker_start]
+        + "function W8n(t){const{children:e}=t;return e}"
+        + renderer[marker_end:]
+    )
+
+# Disable renderer Sentry init and selected non-essential hooks.
+renderer = renderer.replace("I7n();", "", 1)
+for old in (
+    "h.jsx(P7n,{})",  # telemetry user wiring
+    "h.jsx(B8n,{})",  # app-open/app-close analytics event
+    "h.jsx(d7n,{})",  # desktop notifications lifecycle
+    "h.jsx(t7n,{})",  # badge count updates
+    "h.jsx(b7n,{})",  # post-turn diff-comment extraction
+):
+    renderer = renderer.replace(old, "null", 1)
+
+if renderer == original_renderer:
+    print("renderer performance patch patterns not found; skipping")
+else:
+    index_target.write_text(renderer)
+    print(f"patched {index_target}")
+PY
+then
+  echo "Error: power optimization patch failed."
+  cat "$PATCH_LOG"
+  exit 1
+fi
+
+PATCHED_ASAR="$WORK/app.patched.asar"
+"$ASAR_CMD" pack "$ASAR_EXTRACT" "$PATCHED_ASAR" --unpack "**/*.node"
+
+BACKUP_PATH="$ASAR_PATH.bak.$(date +%Y%m%d%H%M%S)"
+cp "$ASAR_PATH" "$BACKUP_PATH"
+cp "$PATCHED_ASAR" "$ASAR_PATH"
+
+echo "Patched low-power visuals in:"
+echo "  $APP_PATH"
+echo "Backup saved at:"
+echo "  $BACKUP_PATH"

--- a/optimize-power.sh
+++ b/optimize-power.sh
@@ -174,6 +174,14 @@ else:
     if count == 0:
         raise SystemExit("unable to patch getLiquidGlassSupport in main bundle")
 
+text, analytics_count = re.subn(
+    r'args:\["app-server","--analytics-default-enabled"\]',
+    'args:["app-server"]',
+    text,
+)
+if analytics_count == 0:
+    print("app-server analytics patch pattern not found; skipping")
+
 target.write_text(text)
 print(f"patched {target}")
 

--- a/start.sh
+++ b/start.sh
@@ -1,9 +1,38 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-APP_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/codex-app/Codex.app"
+BASE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+APP_ROOT="$BASE_DIR/codex-app"
+DEFAULT_APP_DIR="$APP_ROOT/Codex.app"
+APP_DIR="$DEFAULT_APP_DIR"
+
+select_latest_app_dir() {
+  local app_root="$1"
+  local candidate=""
+  local selected=""
+  local selected_mtime=0
+  local candidate_mtime=0
+
+  while IFS= read -r -d '' candidate; do
+    candidate_mtime="$(stat -f '%m' "$candidate")" || continue
+    if [[ -z "$selected" || "$candidate_mtime" -gt "$selected_mtime" ]]; then
+      selected="$candidate"
+      selected_mtime="$candidate_mtime"
+    fi
+  done < <(find "$app_root" -maxdepth 1 -type d -name '*.app' -print0)
+
+  printf '%s' "$selected"
+}
+
+if [[ -d "$APP_ROOT" ]]; then
+  APP_DIR="$(select_latest_app_dir "$APP_ROOT")"
+  if [[ -z "$APP_DIR" ]]; then
+    APP_DIR="$DEFAULT_APP_DIR"
+  fi
+fi
+
 if [[ ! -d "$APP_DIR" ]]; then
-  echo "Codex.app not found at $APP_DIR"
+  echo "Codex app not found at $APP_DIR"
   echo "Run ./install.sh first."
   exit 1
 fi


### PR DESCRIPTION
## Summary
- accept local `Codex*.app` bundles as installer input in addition to DMGs
- preserve the original app bundle name and plist metadata so Beta installs side by side as `Codex (Beta).app`
- update patch target resolution for newer `.vite/build` layouts and add the in-place `optimize-power.sh` helper
- make `start.sh` launch the newest generated app bundle and document the Beta workflow

## Verification
- `bash -n install.sh start.sh optimize-power.sh`
- `./install.sh "./Codex (Beta).app"`
- verified `/Applications/Codex (Beta).app/Contents/Info.plist` reports `CFBundleDisplayName = Codex (Beta)` and `CFBundleIdentifier = com.openai.codex.beta`


## Remote Connection
<img width="851" height="1200" alt="image" src="https://github.com/user-attachments/assets/3e25f514-da6a-4ad8-aefd-fc84840ee8d5" />
